### PR TITLE
Workaround for issue #16 (in parent)

### DIFF
--- a/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
@@ -303,4 +303,20 @@ public class GPSdEndpoint {
 			}
 		}
 	}
+
+	/**
+	 * Attempt to kick a failed device back into life on gpsd server.
+	 *  
+	 * @see https://lists.gnu.org/archive/html/gpsd-dev/2015-06/msg00001.html
+	 *  
+	 * @param path Path of device known to gpsd
+	 * @throws IOException
+	 * @throws JSONException
+	 */
+	public void kickDevice(String path) throws IOException, JSONException {
+		final JSONObject d = new JSONObject();
+		d.put("class", "DEVICE");
+		d.put("path", path);
+		voidCommand("?DEVICE="+d);	
+	}
 }

--- a/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
@@ -129,8 +129,9 @@ public class GPSdEndpoint {
 
 		try {
 			this.listeners.clear();
-			if(listenThread != null)
+			if(listenThread != null) {
 				this.listenThread.halt();
+			}
 		} catch (final Exception e) {
 			GPSdEndpoint.LOG.debug("Interrupted while waiting for listenThread to stop", e);
 		}

--- a/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
@@ -122,7 +122,15 @@ public class GPSdEndpoint {
 	 */
 	public void stop() {
 		try {
-			this.listenThread.halt();
+			socket.close();
+		} catch (final IOException e1) {
+			GPSdEndpoint.LOG.debug("Close forced: "+ e1.getMessage());
+		}
+
+		try {
+			this.listeners.clear();
+			if(listenThread != null)
+				this.listenThread.halt();
 		} catch (final Exception e) {
 			GPSdEndpoint.LOG.debug("Interrupted while waiting for listenThread to stop", e);
 		}


### PR DESCRIPTION
A deadlock in halt can be avoided by closing the underlying socket
stream which will end the read and free the lock.