### PR TITLE
Added null-check to toString().

### DIFF
--- a/src/main/java/de/taimos/gpsd4java/types/TPVObject.java
+++ b/src/main/java/de/taimos/gpsd4java/types/TPVObject.java
@@ -539,8 +539,10 @@ public class TPVObject implements IGPSObject {
 		sb.append(this.speedError);
 		sb.append(", climbRateError=");
 		sb.append(this.climbRateError);
-		sb.append(", mode=");
-		sb.append(this.mode.name());
+		if (mode != null) {
+			sb.append(", mode=");
+			sb.append(this.mode.name());
+		}
 		sb.append("}");
 		return sb.toString();
 	}


### PR DESCRIPTION
Hi,

Current `TPVObject#toString()` implementation can produce `NPE`, as `mode` can be `null`. 

Added extra null check to prevent this behavior.

Cheers!