### PR TITLE
Concurrency fixes

### DIFF
--- a/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
@@ -351,4 +351,14 @@ public class GPSdEndpoint {
 		retryInterval.set(millis);
 	}
 	
+	/**
+	 * Returns the retry interval for reconnecting to GPSD if the socket closes.
+	 * Default value is 1000ms.
+	 *
+	 * @return retry interval
+	 */
+	public long getRetryInterval() {
+		return retryInterval.get();
+	}
+	
 }

--- a/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
@@ -117,12 +117,6 @@ public class GPSdEndpoint {
 	public void start() {
 		this.listenThread = new SocketThread(this.in, this, this.resultParser);
 		this.listenThread.start();
-		
-		try {
-			Thread.sleep(500);
-		} catch (final InterruptedException e) {
-			GPSdEndpoint.LOG.debug("Interrupted while sleeping", e);
-		}
 	}
 	
 	/**
@@ -136,14 +130,12 @@ public class GPSdEndpoint {
 			GPSdEndpoint.LOG.debug("Close forced: " + e1.getMessage());
 		}
 		
-		try {
-			this.listeners.clear();
-			if (this.listenThread != null) {
-				this.listenThread.halt();
-			}
-		} catch (final Exception e) {
-			GPSdEndpoint.LOG.debug("Interrupted while waiting for listenThread to stop", e);
+		this.listeners.clear();
+		
+		if (this.listenThread != null) {
+			this.listenThread.halt();
 		}
+		
 		this.listenThread = null;
 	}
 	

--- a/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/GPSdEndpoint.java
@@ -65,6 +65,8 @@ public class GPSdEndpoint {
 	
 	private SocketThread listenThread;
 	
+	private final boolean daemon;
+	
 	private final List<IObjectListener> listeners = new ArrayList<IObjectListener>(1);
 	
 	private IGPSObject asyncResult = null;
@@ -88,11 +90,13 @@ public class GPSdEndpoint {
 	 *
 	 * @param server       the server name or IP
 	 * @param port         the server port
-	 * @param resultParser
+	 * @param resultParser the result parser
+	 * @param daemon       whether to start the underlying socket thread as a daemon, as defined in {@link Thread#setDaemon}  
 	 * @throws UnknownHostException
 	 * @throws IOException
 	 */
-	public GPSdEndpoint(final String server, final int port, final AbstractResultParser resultParser) throws UnknownHostException, IOException {
+	public GPSdEndpoint(final String server, final int port, final AbstractResultParser resultParser, final boolean daemon) 
+			throws UnknownHostException, IOException {
 		this.server = server;
 		this.port = port;
 		if (server == null) {
@@ -109,13 +113,28 @@ public class GPSdEndpoint {
 		this.in = new BufferedReader(new InputStreamReader(this.socket.getInputStream()));
 		this.out = new BufferedWriter(new OutputStreamWriter(this.socket.getOutputStream()));
 		this.resultParser = resultParser;
+		
+		this.daemon = daemon;
+	}
+	
+	/**
+	 * Instantiate this class to connect to a GPSd server
+	 *
+	 * @param server       the server name or IP
+	 * @param port         the server port
+	 * @param resultParser the result parser
+	 * @throws UnknownHostException
+	 * @throws IOException
+	 */
+	public GPSdEndpoint(final String server, final int port, final AbstractResultParser resultParser) throws UnknownHostException, IOException {
+		this(server, port, resultParser, true);
 	}
 	
 	/**
 	 * start the endpoint
 	 */
 	public void start() {
-		this.listenThread = new SocketThread(this.in, this, this.resultParser);
+		this.listenThread = new SocketThread(this.in, this, this.resultParser, this.daemon);
 		this.listenThread.start();
 	}
 	
@@ -324,7 +343,7 @@ public class GPSdEndpoint {
 			this.in = new BufferedReader(new InputStreamReader(this.socket.getInputStream()));
 			this.out = new BufferedWriter(new OutputStreamWriter(this.socket.getOutputStream()));
 			
-			this.listenThread = new SocketThread(this.in, this, this.resultParser);
+			this.listenThread = new SocketThread(this.in, this, this.resultParser, this.daemon);
 			this.listenThread.start();
 			if (lastWatch != null) { // restore watch if we had one.
 				this.syncCommand(lastWatch, WatchObject.class);

--- a/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
@@ -64,7 +64,6 @@ public class SocketThread extends Thread {
 		this.endpoint = endpoint;
 		this.resultParser = resultParser;
 		
-		this.setDaemon(true);
 		this.setName("GPS Socket Thread");
 	}
 	

--- a/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
@@ -71,9 +71,9 @@ public class SocketThread extends Thread {
 	}
 	
 	/**
-	 * @param reader			the socket input
-	 * @param endpoint		the endpoint
-	 * @param resultParser	the result parser
+	 * @param reader        the socket input
+	 * @param endpoint      the endpoint
+	 * @param resultParser  the result parser
 	 */
 	public SocketThread(final BufferedReader reader, final GPSdEndpoint endpoint, final AbstractResultParser resultParser) {
 		this(reader, endpoint, resultParser, true);

--- a/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
@@ -47,9 +47,11 @@ public class SocketThread extends Thread {
 	/**
 	 * @param reader       the socket input
 	 * @param endpoint     the endpoint
-	 * @param resultParser
+	 * @param resultParser the result parser
+	 * @param daemon       whether to configure the thread as a daemon, as defined in {@link Thread#setDaemon}
 	 */
-	public SocketThread(final BufferedReader reader, final GPSdEndpoint endpoint, final AbstractResultParser resultParser) {
+	public SocketThread(final BufferedReader reader, final GPSdEndpoint endpoint, 
+							  final AbstractResultParser resultParser, final boolean daemon) {
 		if (reader == null) {
 			throw new IllegalArgumentException("reader can not be null!");
 		}
@@ -64,7 +66,17 @@ public class SocketThread extends Thread {
 		this.endpoint = endpoint;
 		this.resultParser = resultParser;
 		
+		this.setDaemon(daemon);
 		this.setName("GPS Socket Thread");
+	}
+	
+	/**
+	 * @param reader			the socket input
+	 * @param endpoint		the endpoint
+	 * @param resultParser	the result parser
+	 */
+	public SocketThread(final BufferedReader reader, final GPSdEndpoint endpoint, final AbstractResultParser resultParser) {
+		this(reader, endpoint, resultParser, true);
 	}
 	
 	@Override

--- a/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
@@ -99,7 +99,7 @@ public class SocketThread extends Thread {
 		
 		while (this.running.get()) {
 			try {
-				running.waitFor(1000);
+				running.waitFor(this.endpoint.getRetryInterval());
 				this.endpoint.handleDisconnected();
 				SocketThread.LOG.debug("Reconnected to GPS socket");
 				running.set(false);

--- a/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
+++ b/src/main/java/de/taimos/gpsd4java/backend/SocketThread.java
@@ -114,15 +114,14 @@ public class SocketThread extends Thread {
 	/**
 	 * Halts the socket thread.
 	 *
-	 * @throws InterruptedException
 	 */
-	public void halt() throws InterruptedException {
+	public void halt() {
 		this.running.set(false);
+		
 		try {
 			this.reader.close();
 		} catch (final IOException e) {
 			// ignore
 		}
-		this.join(1000);
 	}
 }


### PR DESCRIPTION
* **Use GPSdEndpoint's retryInterval when retrying connection**

* **Remove magic sleep()'s and join()'s**
I've tested and found that these have no effect whatsoever, so I removed them. Also it didn't seem like a good idea to block the calling thread with arbitrary timeouts. Please let me know if I missed their purpose.

* **Don't create SocketThread as a daemon thread**
This change makes using the API cleaner and the library easier to use for developers because they won't need to use `sleep()` or `join()` the SocketThread, which in fact is private to the GPSdEndpoint instance and gets reinstantiated upon reconnecting. 
The change I'm proposing seems like the cleanest and simplest solution compared to just exposing the SocketThread via a getter as this would impose developers to write much more complex logic to handle concurrency and reconnections.
Also, by not being a daemon, the SocketThread keeps running until `GPSdEndpoint::stop()` gets called.